### PR TITLE
Add additional properties (total water and ion exchange capacity)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -103,6 +103,12 @@ Get the current amount of available water (integer)
 water_available = device.water_available
 ```
 
+Get total water counter (integer)
+
+```python
+water_total_counter = device.water_total_counter
+```
+
 ### Water Flow
 
 Get the current water flow rate (float)
@@ -149,6 +155,23 @@ Get the total amount of rock removed by the device over its lifetime (float)
 
 ```python
 rock_removed = device.rock_removed
+```
+
+### Ion exchange capacity
+
+Get current ion exchange capacity (integer)
+```python
+ion_operating_capacity = device.ion_operating_capacity
+```
+
+Get remaining ion exchange capacity in percent (float)
+```python
+ion_capacity_remaining = device.ion_capacity_remaining
+```
+
+Get average capacity remaining until exhaustion in percent (float)
+```python
+ion_average_exhaustion = device.ion_average_exhaustion
 ```
 
 ### Recharge

--- a/ecowater_softener/ecowater.py
+++ b/ecowater_softener/ecowater.py
@@ -55,6 +55,10 @@ class EcowaterDevice(ayla_iot_unofficial.device.Device):
     def water_available(self) -> int:
         return self.get_property_value("treated_water_avail_gals")
     
+    @property
+    def water_total_counter(self) -> int:
+        return self.get_property_value("water_counter_gals")
+
     # Water flow
 
     @property
@@ -92,6 +96,19 @@ class EcowaterDevice(ayla_iot_unofficial.device.Device):
     def rock_removed(self) -> float:
         return self.get_property_value("total_rock_removed_lbs") / 10
     
+    # Ion exchange capacity
+    @property
+    def ion_operating_capacity(self) -> int:
+        return self.get_property_value("operating_capacity_grains")
+
+    @property
+    def ion_capacity_remaining(self) -> int:
+        return self.get_property_value("capacity_remaining_percent") / 10.0
+
+    @property
+    def ion_average_exhaustion(self) -> int:
+        return (1000 - self.get_property_value("average_exhaustion_percent")) / 10.0
+
     # Recharge
     @property
     def recharge_status(self) -> str:


### PR DESCRIPTION
Add additional properties. These are useful for statistics and calculations relating to automatic regeneration, as the scheduled automatic regeneration is not visible in the API.